### PR TITLE
ImageOverhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist/
 # Rider
 .idea/
 /publish
+/src/Bitcraft.ResourceFinder.Web/publish

--- a/src/Bitcraft.ResourceFinder.Web/Data/AppDbContext.cs
+++ b/src/Bitcraft.ResourceFinder.Web/Data/AppDbContext.cs
@@ -14,6 +14,8 @@ public class AppDbContext : IdentityDbContext
     public DbSet<TypeItem> Types => Set<TypeItem>();
     public DbSet<Biome> Biomes => Set<Biome>();
     public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
+    public DbSet<PendingImage> PendingImages => Set<PendingImage>();
+    public DbSet<Report> Reports => Set<Report>();
 
     protected override void OnModelCreating(ModelBuilder b)
     {
@@ -41,5 +43,23 @@ public class AppDbContext : IdentityDbContext
         b.Entity<ResourceAlias>()
             .HasIndex(x => new { x.ResourceId, x.CanonicalAlias })
             .IsUnique();
+
+        b.Entity<PendingImage>()
+        .HasOne(p => p.Resource)
+        .WithMany() // no back-collection on Resource to keep it simple
+        .HasForeignKey(p => p.ResourceId)
+        .OnDelete(DeleteBehavior.Cascade);
+
+        b.Entity<PendingImage>()
+            .HasIndex(p => p.ResourceId);
+
+        b.Entity<Report>()
+            .HasOne(r => r.Resource)
+            .WithMany() // no back-collection to keep Resource flat
+            .HasForeignKey(r => r.ResourceId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        b.Entity<Report>()
+            .HasIndex(r => new { r.ResourceId, r.Status });
     }
 }

--- a/src/Bitcraft.ResourceFinder.Web/Migrations/20250924194248_PendingImagesAndReports.Designer.cs
+++ b/src/Bitcraft.ResourceFinder.Web/Migrations/20250924194248_PendingImagesAndReports.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Bitcraft.ResourceFinder.Web.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Bitcraft.ResourceFinder.Web.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250924194248_PendingImagesAndReports")]
+    partial class PendingImagesAndReports
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Bitcraft.ResourceFinder.Web/Migrations/20250924194248_PendingImagesAndReports.cs
+++ b/src/Bitcraft.ResourceFinder.Web/Migrations/20250924194248_PendingImagesAndReports.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Bitcraft.ResourceFinder.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class PendingImagesAndReports : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PendingImages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ResourceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Img256Url = table.Column<string>(type: "text", nullable: false),
+                    Img512Url = table.Column<string>(type: "text", nullable: false),
+                    ImagePhash = table.Column<string>(type: "text", nullable: true),
+                    UploadedByUserId = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PendingImages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PendingImages_Resources_ResourceId",
+                        column: x => x.ResourceId,
+                        principalTable: "Resources",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Reports",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Target = table.Column<int>(type: "integer", nullable: false),
+                    Reason = table.Column<int>(type: "integer", nullable: false),
+                    ResourceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Notes = table.Column<string>(type: "text", nullable: true),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedByUserId = table.Column<string>(type: "text", nullable: true),
+                    ResolvedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ResolvedByUserId = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Reports", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Reports_Resources_ResourceId",
+                        column: x => x.ResourceId,
+                        principalTable: "Resources",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingImages_ResourceId",
+                table: "PendingImages",
+                column: "ResourceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Reports_ResourceId_Status",
+                table: "Reports",
+                columns: new[] { "ResourceId", "Status" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PendingImages");
+
+            migrationBuilder.DropTable(
+                name: "Reports");
+        }
+    }
+}

--- a/src/Bitcraft.ResourceFinder.Web/Models/Entities.cs
+++ b/src/Bitcraft.ResourceFinder.Web/Models/Entities.cs
@@ -1,9 +1,12 @@
-
 using System.ComponentModel.DataAnnotations;
 
 namespace Bitcraft.ResourceFinder.Web.Models;
 
 public enum ResourceStatus { Unconfirmed = 0, Confirmed = 1 }
+public enum ReportReason { Incorrect = 0, ViolatesPolicy = 1 }
+public enum ReportTargetType { Resource = 0, AcceptedImage = 1 }
+public enum ReportStatus { Open = 0, Closed = 1 }
+
 
 public class TypeItem
 {
@@ -72,4 +75,41 @@ public class AuditLog
     public string? SubjectId { get; set; }
     public string? DiffJson { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+
+public class PendingImage
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid ResourceId { get; set; }
+    public Resource? Resource { get; set; }
+
+    // store processed, webp thumbnails like accepted images
+    public string Img256Url { get; set; } = "";
+    public string Img512Url { get; set; } = "";
+    public string? ImagePhash { get; set; }
+
+    public string? UploadedByUserId { get; set; }   // IdentityUser Id (string GUID)
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+
+public class Report
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public ReportTargetType Target { get; set; } = ReportTargetType.Resource;
+    public ReportReason Reason { get; set; } = ReportReason.Incorrect;
+
+    public Guid ResourceId { get; set; }
+    public Resource? Resource { get; set; }
+
+    // If Target == AcceptedImage, this refers to the resource's current official image.
+    // We don't have a row for accepted image; it lives on Resource itself.
+    public string? Notes { get; set; }
+
+    public ReportStatus Status { get; set; } = ReportStatus.Open;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public string? CreatedByUserId { get; set; }
+    public DateTime? ResolvedAt { get; set; }
+    public string? ResolvedByUserId { get; set; }
 }

--- a/src/Bitcraft.ResourceFinder.Web/Models/ViewModels/ReportForm.cs
+++ b/src/Bitcraft.ResourceFinder.Web/Models/ViewModels/ReportForm.cs
@@ -1,0 +1,9 @@
+﻿namespace Bitcraft.ResourceFinder.Web.Models
+{
+    public class ReportForm
+    {
+        public ReportTargetType Target { get; set; } = ReportTargetType.Resource;
+        public ReportReason Reason { get; set; } = ReportReason.Incorrect;
+        public string? Notes { get; set; }
+    }
+}

--- a/src/Bitcraft.ResourceFinder.Web/Views/Admin/Edit.cshtml
+++ b/src/Bitcraft.ResourceFinder.Web/Views/Admin/Edit.cshtml
@@ -27,13 +27,13 @@
                     {
                         @rep.Notes
                     }
-                    <form method="post" action="/admin/reports/@rep.Id/close" class="d-inline ms-2">
+                    <form method="post" action="@Url.Content($"~/admin/reports/{rep.Id}/close")" class="d-inline ms-2">
                                                @Html.AntiForgeryToken()
                         <button class="btn btn-sm btn-outline-dark">Mark resolved</button>
                     </form>
                     @if (rep.Target == Bitcraft.ResourceFinder.Web.Models.ReportTargetType.AcceptedImage && !string.IsNullOrEmpty(Model.Img256Url))
                     {
-                        <form method="post" action="/admin/resources/@Model.Id/remove-accepted-image" class="d-inline ms-2"
+                        <form method="post" action="@Url.Content($"~/admin/resources/{Model.Id}/remove-accepted-image")" class="d-inline ms-2"
                               onsubmit="return confirm('Remove the accepted image?');">
                             @Html.AntiForgeryToken()
                             <button class="btn btn-sm btn-outline-danger">Remove accepted image</button>
@@ -50,7 +50,7 @@
     <div class="card p-3 mb-3 border-warning">
         <div class="d-flex align-items-center justify-content-between mb-2">
             <h5 class="m-0">Pending Images (@pending.Count)</h5>
-            <form method="post" action="/admin/resources/@Model.Id/purge-pending" onsubmit="return confirm('Purge all pending images?');">
+            <form method="post" action="@Url.Content($"~/admin/resources/{Model.Id}/purge-pending")" onsubmit="return confirm('Purge all pending images?');">
                 @Html.AntiForgeryToken()
                 <button class="btn btn-sm btn-outline-danger">Purge all</button>
             </form>
@@ -61,7 +61,7 @@
                 <div class="col-auto text-center">
                     <img src="@Url.Content(p.Img256Url)" width="128" height="128" class="rounded border mb-2" />
                     <div>
-                        <form method="post" action="/admin/resources/@Model.Id/accept-pending/@p.Id" class="d-inline">
+                        <form method="post" action="@Url.Content($"~/admin/resources/{Model.Id}/accept-pending/{p.Id}")" class="d-inline">
                             @Html.AntiForgeryToken()
                             <button class="btn btn-sm btn-primary">Accept</button>
                         </form>
@@ -82,7 +82,6 @@
             @Html.ValidationSummary(excludePropertyErrors: true)
         </div>
     }
-
 
     <div class="row g-3">
         <div class="col-md-2">
@@ -151,9 +150,6 @@
             <!-- Image cropper (512×512 PNG) -->
             <input type="hidden" name="returnUrl" value="@ViewBag.ReturnUrl" />
             <div class="image-crop-512" data-field="file" data-proxy-url="@Url.Content("~/image-proxy?url=")"></div>
-
-
-
         </div>
 
         <div class="col-md-12">

--- a/src/Bitcraft.ResourceFinder.Web/Views/Admin/Edit.cshtml
+++ b/src/Bitcraft.ResourceFinder.Web/Views/Admin/Edit.cshtml
@@ -28,12 +28,14 @@
                         @rep.Notes
                     }
                     <form method="post" action="/admin/reports/@rep.Id/close" class="d-inline ms-2">
+                                               @Html.AntiForgeryToken()
                         <button class="btn btn-sm btn-outline-dark">Mark resolved</button>
                     </form>
                     @if (rep.Target == Bitcraft.ResourceFinder.Web.Models.ReportTargetType.AcceptedImage && !string.IsNullOrEmpty(Model.Img256Url))
                     {
                         <form method="post" action="/admin/resources/@Model.Id/remove-accepted-image" class="d-inline ms-2"
                               onsubmit="return confirm('Remove the accepted image?');">
+                            @Html.AntiForgeryToken()
                             <button class="btn btn-sm btn-outline-danger">Remove accepted image</button>
                         </form>
                     }
@@ -49,6 +51,7 @@
         <div class="d-flex align-items-center justify-content-between mb-2">
             <h5 class="m-0">Pending Images (@pending.Count)</h5>
             <form method="post" action="/admin/resources/@Model.Id/purge-pending" onsubmit="return confirm('Purge all pending images?');">
+                @Html.AntiForgeryToken()
                 <button class="btn btn-sm btn-outline-danger">Purge all</button>
             </form>
         </div>
@@ -56,9 +59,10 @@
             @foreach (var p in pending)
             {
                 <div class="col-auto text-center">
-                    <img src="@p.Img256Url" width="128" height="128" class="rounded border mb-2" />
+                    <img src="@Url.Content(p.Img256Url)" width="128" height="128" class="rounded border mb-2" />
                     <div>
                         <form method="post" action="/admin/resources/@Model.Id/accept-pending/@p.Id" class="d-inline">
+                            @Html.AntiForgeryToken()
                             <button class="btn btn-sm btn-primary">Accept</button>
                         </form>
                     </div>

--- a/src/Bitcraft.ResourceFinder.Web/Views/Admin/Edit.cshtml
+++ b/src/Bitcraft.ResourceFinder.Web/Views/Admin/Edit.cshtml
@@ -6,6 +6,68 @@
     var types = ViewBag.Types as List<Bitcraft.ResourceFinder.Web.Models.TypeItem>;
     var biomes = ViewBag.Biomes as List<Bitcraft.ResourceFinder.Web.Models.Biome>;
 }
+@{
+    var reports = ViewBag.Reports as List<Bitcraft.ResourceFinder.Web.Models.Report>;
+    var pending = ViewBag.Pending as List<Bitcraft.ResourceFinder.Web.Models.PendingImage>;
+}
+
+@if (reports != null && reports.Count > 0)
+{
+    <div class="alert alert-danger">
+        <div class="d-flex align-items-center justify-content-between">
+            <strong>Reports</strong>
+        </div>
+        <ul class="mb-2">
+            @foreach (var rep in reports)
+            {
+                <li>
+                    <span class="badge bg-danger me-2">@rep.Target</span>
+                    <span class="badge bg-secondary me-2">@rep.Reason</span>
+                    @if (!string.IsNullOrWhiteSpace(rep.Notes))
+                    {
+                        @rep.Notes
+                    }
+                    <form method="post" action="/admin/reports/@rep.Id/close" class="d-inline ms-2">
+                        <button class="btn btn-sm btn-outline-dark">Mark resolved</button>
+                    </form>
+                    @if (rep.Target == Bitcraft.ResourceFinder.Web.Models.ReportTargetType.AcceptedImage && !string.IsNullOrEmpty(Model.Img256Url))
+                    {
+                        <form method="post" action="/admin/resources/@Model.Id/remove-accepted-image" class="d-inline ms-2"
+                              onsubmit="return confirm('Remove the accepted image?');">
+                            <button class="btn btn-sm btn-outline-danger">Remove accepted image</button>
+                        </form>
+                    }
+                </li>
+            }
+        </ul>
+    </div>
+}
+
+@if (pending != null && pending.Count > 0)
+{
+    <div class="card p-3 mb-3 border-warning">
+        <div class="d-flex align-items-center justify-content-between mb-2">
+            <h5 class="m-0">Pending Images (@pending.Count)</h5>
+            <form method="post" action="/admin/resources/@Model.Id/purge-pending" onsubmit="return confirm('Purge all pending images?');">
+                <button class="btn btn-sm btn-outline-danger">Purge all</button>
+            </form>
+        </div>
+        <div class="row g-3">
+            @foreach (var p in pending)
+            {
+                <div class="col-auto text-center">
+                    <img src="@p.Img256Url" width="128" height="128" class="rounded border mb-2" />
+                    <div>
+                        <form method="post" action="/admin/resources/@Model.Id/accept-pending/@p.Id" class="d-inline">
+                            <button class="btn btn-sm btn-primary">Accept</button>
+                        </form>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+}
+
 <h3>Edit Resource</h3>
 <form method="post" enctype="multipart/form-data">
     @Html.AntiForgeryToken()

--- a/src/Bitcraft.ResourceFinder.Web/Views/Admin/Index.cshtml
+++ b/src/Bitcraft.ResourceFinder.Web/Views/Admin/Index.cshtml
@@ -242,51 +242,46 @@
   <thead>
         <tr><th>Name</th><th>Tier</th><th>Type</th><th>Biome</th><th>Has Image</th><th>Status</th><th></th></tr>
   </thead>
-  <tbody>
+    <tbody>
+        @{
+            var openReports = ViewBag.OpenReports as Dictionary<Guid, int>;
+            var pendingCounts = ViewBag.PendingCounts as Dictionary<Guid, int>;
+        }
         @foreach (var r in Model)
         {
-            <tr>
-                <td>@r.Name</td>
+            var hasReport = openReports != null && openReports.ContainsKey(r.Id);
+            var hasPending = pendingCounts != null && pendingCounts.ContainsKey(r.Id);
+            var trClass = hasReport ? "table-danger" : (hasPending ? "table-warning" : "");
+            <tr class="@trClass">
+                <td>
+                    @r.Name
+                    @if (hasReport)
+                    {
+                        <span class="badge bg-danger ms-2">Reported</span>
+                    }
+                    @if (hasPending)
+                    {
+                        <span class="badge bg-warning text-dark ms-1">Pending images: @pendingCounts[r.Id]</span>
+                    }
+                </td>
                 <td>@r.Tier</td>
                 <td>@r.Type?.Name</td>
                 <td>@r.Biome?.Name</td>
-                <td>
-                    @{
-                        var hasImage = !string.IsNullOrWhiteSpace(r.Img256Url) || !string.IsNullOrWhiteSpace(r.Img512Url);
-
-                    }
-                    <span class="badge @(hasImage ? "bg-success" : "bg-secondary")">@(hasImage ? "Yes" : "No")</span>
-
-                </td>
                 <td>@r.Status</td>
                 <td class="text-end">
-                    <!-- Confirm / Unconfirm -->
-                    <form method="post" action="~/admin/resources/@r.Id/status" class="d-inline">
-                        @Html.AntiForgeryToken()
+                    <form method="post" action="/admin/resources/@r.Id/status" class="d-inline">
                         <input type="hidden" name="status" value="@(r.Status == Bitcraft.ResourceFinder.Web.Models.ResourceStatus.Unconfirmed ? "confirmed" : "unconfirmed")" />
-                        <input type="hidden" name="returnUrl" value="@(Context.Request.PathBase + Context.Request.Path + Context.Request.QueryString)" />
-                        <button class="btn btn-sm btn-success">
-                            @(r.Status == Bitcraft.ResourceFinder.Web.Models.ResourceStatus.Unconfirmed ? "Confirm" : "Unconfirm")
-                        </button>
+                        <button class="btn btn-sm btn-success">@(r.Status == Bitcraft.ResourceFinder.Web.Models.ResourceStatus.Unconfirmed ? "Confirm" : "Unconfirm")</button>
                     </form>
-
-                    <!-- Edit -->
-                    <a class="btn btn-sm btn-primary"
-                       href="@Url.Action("Edit", "Admin", new { id = r.Id, returnUrl = Context.Request.PathBase + Context.Request.Path + Context.Request.QueryString })">
-                        Edit
-                    </a>
-
-                    <!-- Delete -->
-                    <form method="post" action="~/admin/resources/@r.Id/delete" class="d-inline" onsubmit="return confirm('Delete this resource?');">
-                        @Html.AntiForgeryToken()
-                        <input type="hidden" name="returnUrl" value="@(Context.Request.PathBase + Context.Request.Path + Context.Request.QueryString)" />
+                    <a class="btn btn-sm btn-primary" href="/admin/resources/@r.Id/edit">Review</a>
+                    <form method="post" action="/admin/resources/@r.Id/delete" class="d-inline" onsubmit="return confirm('Delete this resource?');">
                         <button class="btn btn-sm btn-danger">Delete</button>
                     </form>
                 </td>
+            </tr>
+        }
+    </tbody>
 
-    </tr>
-  }
-  </tbody>
 </table>
 
 @if (pages > 1)

--- a/src/Bitcraft.ResourceFinder.Web/Views/Admin/Index.cshtml
+++ b/src/Bitcraft.ResourceFinder.Web/Views/Admin/Index.cshtml
@@ -267,14 +267,29 @@
                 <td>@r.Tier</td>
                 <td>@r.Type?.Name</td>
                 <td>@r.Biome?.Name</td>
+                <td>
+                    @{
+                        var hasImage = !string.IsNullOrWhiteSpace(r.Img256Url) || !string.IsNullOrWhiteSpace(r.Img512Url);
+
+                    }
+                    <span class="badge @(hasImage ? "bg-success" : "bg-secondary")">
+                        @(hasImage ? "Yes" : "No")
+
+                    </span>
+                
+            </td>
                 <td>@r.Status</td>
                 <td class="text-end">
-                    <form method="post" action="/admin/resources/@r.Id/status" class="d-inline">
+                    <form method="post" action="@Url.Content($"~/admin/resources/{r.Id}/status")" class="d-inline">
+                        @Html.AntiForgeryToken()
                         <input type="hidden" name="status" value="@(r.Status == Bitcraft.ResourceFinder.Web.Models.ResourceStatus.Unconfirmed ? "confirmed" : "unconfirmed")" />
+                        <input type="hidden" name="returnUrl" value="@(Context.Request.PathBase + Context.Request.Path + Context.Request.QueryString)" />
                         <button class="btn btn-sm btn-success">@(r.Status == Bitcraft.ResourceFinder.Web.Models.ResourceStatus.Unconfirmed ? "Confirm" : "Unconfirm")</button>
                     </form>
-                    <a class="btn btn-sm btn-primary" href="/admin/resources/@r.Id/edit">Review</a>
-                    <form method="post" action="/admin/resources/@r.Id/delete" class="d-inline" onsubmit="return confirm('Delete this resource?');">
+                    <a class="btn btn-sm btn-primary" href="@Url.Action("Edit", "Admin", new { id = r.Id, returnUrl = Context.Request.PathBase + Context.Request.Path + Context.Request.QueryString })">Review</a>
+                    <form method="post" action="@Url.Content($"~/admin/resources/{r.Id}/delete")" class="d-inline" onsubmit="return confirm('Delete this resource?');">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" name="returnUrl" value="@(Context.Request.PathBase + Context.Request.Path + Context.Request.QueryString)" />
                         <button class="btn btn-sm btn-danger">Delete</button>
                     </form>
                 </td>

--- a/src/Bitcraft.ResourceFinder.Web/Views/Resources/AddImage.cshtml
+++ b/src/Bitcraft.ResourceFinder.Web/Views/Resources/AddImage.cshtml
@@ -6,7 +6,7 @@
 
 <h2 class="mb-3">Add Image for “@Model.Name”</h2>
 
-<form method="post" enctype="multipart/form-data" action="/resources/@Model.Id/add-image">
+<form method="post" enctype="multipart/form-data" action="@Url.Content($"~/resources/{Model.Id}/add-image")">
     @Html.AntiForgeryToken()
 
     <div class="mb-3">

--- a/src/Bitcraft.ResourceFinder.Web/Views/Resources/AddImage.cshtml
+++ b/src/Bitcraft.ResourceFinder.Web/Views/Resources/AddImage.cshtml
@@ -3,14 +3,26 @@
     ViewData["Title"] = "Add Image";
     Layout = "~/Views/Shared/_Layout.cshtml";
 }
-<h3>Add image for “@Model.Name”</h3>
-<div class="card p-4">
-    <form method="post" enctype="multipart/form-data">
-        <div class="mb-3">
-            <label class="form-label">Image (≤ 300 KB; jpg/png/webp)</label>
-            <input class="form-control" type="file" name="image" accept="image/*" required />
-        </div>
-        <button class="btn btn-primary">Submit</button>
-        <a class="btn btn-secondary" href="/resources">Cancel</a>
-    </form>
-</div>
+
+<h2 class="mb-3">Add Image for “@Model.Name”</h2>
+
+<form method="post" enctype="multipart/form-data" action="/resources/@Model.Id/add-image">
+    @Html.AntiForgeryToken()
+
+    <div class="mb-3">
+        <!-- The cropper auto-finds its host form; fieldName= image -->
+        <div class="ic512-widget" data-field="image"></div>
+        <small class="text-muted d-block mt-2">Upload, paste, or URL via the cropper. Exports 512×512 WebP (client-side capped at 500 KB).</small>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Submit</button>
+    <a href="@Url.Action("Index", "Resources")" class="btn btn-outline-secondary ms-2">Cancel</a>
+</form>
+
+@section Scripts {
+    <script src="~/js/image-crop-512.js"></script>
+    <script>
+        // Initialize cropper on this page; it will intercept submit and post WebP as the "image" field.
+        window.initImageCrop512('.ic512-widget');
+    </script>
+}

--- a/src/Bitcraft.ResourceFinder.Web/Views/Resources/AddImage.cshtml
+++ b/src/Bitcraft.ResourceFinder.Web/Views/Resources/AddImage.cshtml
@@ -1,0 +1,16 @@
+﻿@model Bitcraft.ResourceFinder.Web.Models.Resource
+@{
+    ViewData["Title"] = "Add Image";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+<h3>Add image for “@Model.Name”</h3>
+<div class="card p-4">
+    <form method="post" enctype="multipart/form-data">
+        <div class="mb-3">
+            <label class="form-label">Image (≤ 300 KB; jpg/png/webp)</label>
+            <input class="form-control" type="file" name="image" accept="image/*" required />
+        </div>
+        <button class="btn btn-primary">Submit</button>
+        <a class="btn btn-secondary" href="/resources">Cancel</a>
+    </form>
+</div>

--- a/src/Bitcraft.ResourceFinder.Web/Views/Resources/Index.cshtml
+++ b/src/Bitcraft.ResourceFinder.Web/Views/Resources/Index.cshtml
@@ -79,11 +79,22 @@
                     <div class="overlay"></div>
 
 </div>
-                <div class="card-body">
-                    <div class="title">@r.Name</div>
-                    <div class="meta">T@(r.Tier) &bull; @(r.Type?.Name ?? "—") &bull; @(r.Biome?.Name ?? "—")</div>
+                <div class="card-body position-relative">
+                    <div class="position-absolute" style="top:0.75rem; right:0.75rem;">
+                        <a class="btn btn-sm btn-outline-danger me-1" href="/resources/@r.Id/report">Report</a>
+                        @if (User?.Identity?.IsAuthenticated ?? false)
+                        {
+                            if (string.IsNullOrEmpty(r.Img256Url))
+                            {
+                                <a class="btn btn-sm btn-outline-primary" href="/resources/@r.Id/add-image">Add image</a>
+                            }
+                        }
+                    </div>
 
-
+                    <h5 class="card-title pe-5">@r.Name</h5>
+                    <p class="card-text mb-1"><strong>Tier:</strong> @r.Tier</p>
+                    <p class="card-text mb-1"><strong>Type:</strong> @r.Type?.Name</p>
+                    <p class="card-text mb-1"><strong>Biome:</strong> @r.Biome?.Name</p>
                     @if (r.Status == Bitcraft.ResourceFinder.Web.Models.ResourceStatus.Unconfirmed)
                     {
                         <span class="badge badge-unconfirmed">Unconfirmed</span>
@@ -93,6 +104,7 @@
                         <span class="badge badge-confirmed">Confirmed</span>
                     }
                 </div>
+
             </div>
         </div>
     }

--- a/src/Bitcraft.ResourceFinder.Web/Views/Resources/Index.cshtml
+++ b/src/Bitcraft.ResourceFinder.Web/Views/Resources/Index.cshtml
@@ -50,7 +50,7 @@
     </div>
     <div class="col-md-12">
       <button class="btn btn-primary">Apply</button>
-      <a class="btn btn-secondary" href="/resources">Reset</a>
+            <a class="btn btn-secondary" href="@Url.Content("~/resources")">Reset</a>
     </div>
   </form>
 </div>
@@ -81,12 +81,12 @@
 </div>
                 <div class="card-body position-relative">
                     <div class="position-absolute" style="top:0.75rem; right:0.75rem;">
-                        <a class="btn btn-sm btn-outline-danger me-1" href="/resources/@r.Id/report">Report</a>
+                        <a class="btn btn-sm btn-outline-danger me-1" href="@Url.Content($"~/resources/{r.Id}/report")">Report</a>
                         @if (User?.Identity?.IsAuthenticated ?? false)
                         {
                             if (string.IsNullOrEmpty(r.Img256Url))
                             {
-                                <a class="btn btn-sm btn-outline-primary" href="/resources/@r.Id/add-image">Add image</a>
+                                <a class="btn btn-sm btn-outline-primary" href="@Url.Content($"~/resources/{r.Id}/add-image")">Add image</a>
                             }
                         }
                     </div>

--- a/src/Bitcraft.ResourceFinder.Web/Views/Resources/Report.cshtml
+++ b/src/Bitcraft.ResourceFinder.Web/Views/Resources/Report.cshtml
@@ -1,0 +1,35 @@
+﻿@model Bitcraft.ResourceFinder.Web.Models.ReportForm
+@{
+    ViewData["Title"] = "Report";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+    var res = ViewBag.Resource as Bitcraft.ResourceFinder.Web.Models.Resource;
+}
+<h3>Report “@res?.Name”</h3>
+<div class="card p-4">
+  <form method="post">
+    <div class="mb-3">
+      <label class="form-label">What are you reporting?</label>
+            <select class="form-select" name="Target">
+                <option value="0">Resource info</option>
+                @if (!string.IsNullOrEmpty(res?.Img256Url))
+                {
+                    <option value="1">Accepted image</option>
+                }
+            </select>
+
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Reason</label>
+      <select class="form-select" name="Reason">
+        <option value="0">Incorrect</option>
+        <option value="1">Violates policy</option>
+      </select>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Notes (optional)</label>
+      <textarea class="form-control" name="Notes" rows="3"></textarea>
+    </div>
+    <button class="btn btn-danger">Submit report</button>
+    <a class="btn btn-secondary" href="/resources">Cancel</a>
+  </form>
+</div>

--- a/src/Bitcraft.ResourceFinder.Web/Views/Resources/Report.cshtml
+++ b/src/Bitcraft.ResourceFinder.Web/Views/Resources/Report.cshtml
@@ -7,6 +7,7 @@
 <h3>Report “@res?.Name”</h3>
 <div class="card p-4">
   <form method="post">
+        @Html.AntiForgeryToken()
     <div class="mb-3">
       <label class="form-label">What are you reporting?</label>
             <select class="form-select" name="Target">
@@ -30,6 +31,6 @@
       <textarea class="form-control" name="Notes" rows="3"></textarea>
     </div>
     <button class="btn btn-danger">Submit report</button>
-    <a class="btn btn-secondary" href="/resources">Cancel</a>
+        <a class="btn btn-secondary" href="@Url.Content("~/resources")">Cancel</a>
   </form>
 </div>


### PR DESCRIPTION
Overhaul of the image handling system to use a pending image admin review system.  This should greatly reduce the chance of unwanted images being presented to the front end. 

Duplicate image checking (this may not yet be hooked up but the logic has been started)

**Registered Users**

- Add image to pending for any existing Resource
- Images submitted with New Resources will be pending
- Registered users can now report resources for incorrect information, and image / text violations
 
 **Admins**

- Image submissions skip pending for admins
- Admins will see pending images and reports on the Resources Admin page.
- Admins can approve images, purge pending images, remove reported images, and answer reports in the Edit page.